### PR TITLE
Jest setup files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix(ts-lib-scripts): 修复 lint-staged 配置错误
 - fix(eslint-config-ts-lib): 修复单元测试代码提示 `import/no-extraneous-dependencies` 错误
+- fix: 修复无法添加 Jest 初始化配置文件的缺陷 ( #24 )
 
 ## v0.5.1 - 2019.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 变更说明
 
+## v0.5.2 - 2019.11.1
+
+- fix(ts-lib-scripts): 修复 lint-staged 配置错误
+
 ## v0.5.1 - 2019.11.1
 
 - fix(ts-lib-tools): 修复非 monorepo 模式下，单元测试会阻止打包命令执行的错误 ( #23 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.5.2 - 2019.11.1
 
 - fix(ts-lib-scripts): 修复 lint-staged 配置错误
+- fix(eslint-config-ts-lib): 修复单元测试代码提示 `import/no-extraneous-dependencies` 错误
 
 ## v0.5.1 - 2019.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - fix(ts-lib-scripts): 修复 lint-staged 配置错误
 - fix(eslint-config-ts-lib): 修复单元测试代码提示 `import/no-extraneous-dependencies` 错误
-- fix: 修复无法添加 Jest 初始化配置文件的缺陷 ( #24 )
+- fix(ts-lib-tools): 修复无法添加 Jest 初始化配置文件的缺陷 ( #24 )
 
 ## v0.5.1 - 2019.11.1
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -40,7 +40,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
+    "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --fix",
       "git add"
     ]

--- a/packages/eslint-config-ts-lib/index.js
+++ b/packages/eslint-config-ts-lib/index.js
@@ -54,7 +54,18 @@ const eslintConfig = {
     'react-hooks/exhaustive-deps': 'warn',
     'import/no-extraneous-dependencies': [
       'error',
-      { devDependencies: ['**/*.{spec,test}.{ts,tsx,js,jsx}'] },
+      {
+        devDependencies: [
+          '**/*.test.ts',
+          '**/*.test.tsx',
+          '**/*.spec.ts',
+          '**/*.spec.tsx',
+          '**/*.test.js',
+          '**/*.test.jsx',
+          '**/*.spec.js',
+          '**/*.spec.jsx',
+        ],
+      },
     ],
     '@typescript-eslint/explicit-function-return-type': 0,
     'import/named': 0,
@@ -101,8 +112,8 @@ const eslintConfig = {
     ],
     'no-console': ['warn', { allow: ['warn', 'error'] }],
     // 关闭标准的缩进和typescript缩进规则，启用prettier的缩进规则
-    "indent": "off",
-    "@typescript-eslint/indent": "off"
+    indent: 'off',
+    '@typescript-eslint/indent': 'off',
   },
 
   overrides: [

--- a/packages/ts-lib-jsdom-polyfill/LICENSE
+++ b/packages/ts-lib-jsdom-polyfill/LICENSE
@@ -1,0 +1,22 @@
+(The MIT License)
+
+Copyright (c) 2019 sinoui
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/ts-lib-jsdom-polyfill/README.md
+++ b/packages/ts-lib-jsdom-polyfill/README.md
@@ -1,0 +1,3 @@
+# eslint-config-ts-lib
+
+[ts-lib-scripts](https://github.com/sinoui/ts-lib-scripts) 创建的 ts 库项目使用的 ESLint 配置

--- a/packages/ts-lib-jsdom-polyfill/index.js
+++ b/packages/ts-lib-jsdom-polyfill/index.js
@@ -1,0 +1,18 @@
+if (typeof window !== 'undefined') {
+  const raf = window.requestAnimationFrame;
+  const cancelRaf = window.cancelAnimationFrame;
+
+  beforeEach(() => {
+    window.requestAnimationFrame = (callback) => {
+      return setTimeout(callback);
+    };
+    window.cancelAnimationFrame = (rafId) => {
+      clearTimeout(rafId);
+    };
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = raf;
+    window.cancelAnimationFrame = cancelRaf;
+  });
+}

--- a/packages/ts-lib-jsdom-polyfill/index.js
+++ b/packages/ts-lib-jsdom-polyfill/index.js
@@ -1,18 +1,8 @@
 if (typeof window !== 'undefined') {
-  const raf = window.requestAnimationFrame;
-  const cancelRaf = window.cancelAnimationFrame;
-
-  beforeEach(() => {
-    window.requestAnimationFrame = (callback) => {
-      return setTimeout(callback);
-    };
-    window.cancelAnimationFrame = (rafId) => {
-      clearTimeout(rafId);
-    };
-  });
-
-  afterEach(() => {
-    window.requestAnimationFrame = raf;
-    window.cancelAnimationFrame = cancelRaf;
-  });
+  window.requestAnimationFrame = (callback) => {
+    return setTimeout(callback, 16);
+  };
+  window.cancelAnimationFrame = (rafId) => {
+    clearTimeout(rafId);
+  };
 }

--- a/packages/ts-lib-jsdom-polyfill/package.json
+++ b/packages/ts-lib-jsdom-polyfill/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "ts-lib-jsdom-polyfill",
+  "description": "ts库的 jsdom polyfill",
+  "version": "0.5.1",
+  "main": "index.js",
+  "license": "MIT",
+  "homepage": "https://github.com/sinoui/ts-lib-scripts",
+  "bugs": {
+    "url": "https://github.com/sinoui/ts-lib-scripts/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sinoui/ts-lib-scripts.git"
+  },
+  "files": [
+    "index.js"
+  ],
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "2.x",
+    "@typescript-eslint/parser": "2.x",
+    "eslint": "6.x",
+    "eslint-config-airbnb": "18.x",
+    "eslint-config-prettier": "6.x",
+    "eslint-import-resolver-typescript": "1.x",
+    "eslint-plugin-import": "2.x",
+    "eslint-plugin-jsx-a11y": "6.x",
+    "eslint-plugin-prettier": "3.x",
+    "eslint-plugin-react": "7.x",
+    "eslint-plugin-react-hooks": "1.x",
+    "eslint-plugin-standard": "4.x"
+  },
+  "gitHead": "a0ec9d27b2f24cb228993286530f89957d055b9b"
+}

--- a/packages/ts-lib-jsdom-polyfill/tsconfig.json
+++ b/packages/ts-lib-jsdom-polyfill/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["."],
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true
+  }
+}

--- a/packages/ts-lib-scripts/assets/react-template/package.json
+++ b/packages/ts-lib-scripts/assets/react-template/package.json
@@ -35,7 +35,7 @@
     }
   },
   "lint-staged": {
-    "src/*.{ts,tsx}": [
+    "src/**/*.{ts,tsx}": [
       "cross-env CI=true ts-lib-tools test",
       "eslint --fix --color",
       "git add"

--- a/packages/ts-lib-scripts/assets/template/package.json
+++ b/packages/ts-lib-scripts/assets/template/package.json
@@ -35,7 +35,7 @@
     }
   },
   "lint-staged": {
-    "src/*.{ts,tsx}": [
+    "src/**/*.{ts,tsx}": [
       "cross-env CI=true ts-lib-tools test",
       "eslint --fix --color",
       "git add"

--- a/packages/ts-lib-tools/package.json
+++ b/packages/ts-lib-tools/package.json
@@ -66,7 +66,8 @@
     "rollup-plugin-typescript2": "^0.22.1",
     "ts-lib-scripts-utils": "^0.5.0",
     "tsconfig-paths": "^3.8.0",
-    "tslib": "^1.10.0"
+    "tslib": "^1.10.0",
+    "ts-lib-jsdom-polyfill": "^0.5.1"
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",

--- a/packages/ts-lib-tools/src/config/create-jest-config.ts
+++ b/packages/ts-lib-tools/src/config/create-jest-config.ts
@@ -5,7 +5,11 @@
 import chalk from 'chalk';
 import { resolve } from 'path';
 import { isMonorepo } from 'ts-lib-scripts-utils';
-import { getAppPackageInfo, getTestSetups } from './paths';
+import {
+  getAppPackageInfo,
+  getTestSetups,
+  getJestDOMModulePath,
+} from './paths';
 
 const monorepoJestConfig = {
   collectCoverageFrom: [
@@ -22,7 +26,6 @@ const monorepoJestConfig = {
  * 创建Jest配置
  */
 export async function createJestConfig() {
-  const setupTestsFile = getTestSetups();
   const isMono = await isMonorepo();
   const jestConfig: { [x: string]: any } = {
     transform: {
@@ -71,10 +74,9 @@ export async function createJestConfig() {
       '.*/\\.cache/.*',
     ],
     setupFiles: [require.resolve('ts-lib-jsdom-polyfill')],
-    setupFilesAfterEnv: [
-      require.resolve('@testing-library/jest-dom/extend-expect'),
-      setupTestsFile,
-    ].filter(Boolean),
+    setupFilesAfterEnv: [getJestDOMModulePath(), getTestSetups()].filter(
+      Boolean,
+    ),
     ...(isMono ? monorepoJestConfig : {}),
   };
 

--- a/packages/ts-lib-tools/src/config/create-jest-config.ts
+++ b/packages/ts-lib-tools/src/config/create-jest-config.ts
@@ -5,7 +5,7 @@
 import chalk from 'chalk';
 import { resolve } from 'path';
 import { isMonorepo } from 'ts-lib-scripts-utils';
-import { getAppPackageInfo } from './paths';
+import { getAppPackageInfo, getTestSetups } from './paths';
 
 const monorepoJestConfig = {
   collectCoverageFrom: [
@@ -22,6 +22,7 @@ const monorepoJestConfig = {
  * 创建Jest配置
  */
 export async function createJestConfig() {
+  const setupTestsFile = getTestSetups();
   const isMono = await isMonorepo();
   const jestConfig: { [x: string]: any } = {
     transform: {
@@ -69,6 +70,11 @@ export async function createJestConfig() {
       '.*/dist/.*',
       '.*/\\.cache/.*',
     ],
+    setupFiles: [require.resolve('ts-lib-jsdom-polyfill')],
+    setupFilesAfterEnv: [
+      require.resolve('@testing-library/jest-dom/extend-expect'),
+      setupTestsFile,
+    ].filter(Boolean),
     ...(isMono ? monorepoJestConfig : {}),
   };
 
@@ -121,7 +127,7 @@ export async function createJestConfig() {
           chalk.red(
             `在package.json中发现了${chalk.bold('setupFilesAfterEnv')}。\n\n` +
               `请将它删除掉, 并将你的初始化代码放在 ${chalk.bold(
-                'src/setupTests.js',
+                'src/setupTests.ts',
               )}。\n这个文件会自动加载。\n`,
           ),
         );

--- a/packages/ts-lib-tools/src/config/paths.ts
+++ b/packages/ts-lib-tools/src/config/paths.ts
@@ -45,6 +45,7 @@ export const getAppVersion = () => {
 export const resolveModule = (
   resolveFn: (relativePath: string) => string,
   filePath: string,
+  testExists = false,
 ) => {
   const extension = moduleFileExtensions.find((_) =>
     existsSync(resolveFn(`${filePath}.${_}`)),
@@ -54,7 +55,7 @@ export const resolveModule = (
     return resolveFn(`${filePath}.${extension}`);
   }
 
-  return resolveFn(`${filePath}.ts`);
+  return testExists ? '' : resolveFn(`${filePath}.ts`);
 };
 
 /**
@@ -90,7 +91,8 @@ export const MODULE_TEMPLATE_PATH = resolve(ASSETS_PATH, './module-template');
 /**
  * 获取初始化测试文件
  */
-export const getTestSetups = () => resolveModule(resolveRoot, 'src/setupTests');
+export const getTestSetups = () =>
+  resolveModule(resolveRoot, 'src/setupTests', true);
 
 /**
  * 获取 @testing-library/jest-dom 模块的路径

--- a/packages/ts-lib-tools/src/config/paths.ts
+++ b/packages/ts-lib-tools/src/config/paths.ts
@@ -88,6 +88,22 @@ export const DIST_PATH = resolveRoot('./dist');
 export const MODULE_TEMPLATE_PATH = resolve(ASSETS_PATH, './module-template');
 
 /**
+ * 获取初始化测试文件
+ */
+export const getTestSetups = () => resolveModule(resolveRoot, 'src/setupTests');
+
+/**
+ * 获取 @testing-library/jest-dom 模块的路径
+ */
+export const getJestDOMModulePath = () => {
+  try {
+    return require.resolve('@testing-library/jest-dom/extend-expect');
+  } catch {
+    return undefined;
+  }
+};
+
+/**
  * 库对应的全局名称
  */
 export const globals = () => {


### PR DESCRIPTION
Jest初始化配置文件

Jest 提供了两个非常有用的配置：

* setupFiles: 指定一组可以配置或者初始化测试环境的模块的路径。每个初始化文件都会在执行每个测试文件之前执行一次。会在创建测试环境之前执行 setupFiles，所以不能在 setupFiles 中做 jest 的扩展。它的用途例如：提供polyfill，比如使用 setTimeout 模拟 requestAnimateFrame 的实现，便于测试。
* setupFIlesAfterEnv: 与 setupFiles 的作用类似，但是会在测试环境创建后执行，所以适合做 jest 的扩展，比如引入 `import '@testing-library/jest-dom/extend-expect'`。

事项：

* [x] 可以在 src/setupTests.ts 或者 src/setupTests.tsx 中定义 jest 环境扩展 (setupFilesAfterEnv)
* [x] React 模式下自动引入 `@testing-library/jest-dom/extend-expect`
* [x] 使用 setTimeout 模拟 requestAnimateFrame 的实现